### PR TITLE
feat: MessageSource 인터페이스 기반 메시지 테스트 코드 작성

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-spring.messages.basename=messages`
+spring.messages.basename=messages,config.i18n.messages
+spring.messages.encoding=UTF-8

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,2 +1,2 @@
-hello=??
-hello.name=?? {0}
+hello=안녕
+hello.name=안녕 {0}

--- a/src/test/java/hello/itemservice/message/MessageSourceTest.java
+++ b/src/test/java/hello/itemservice/message/MessageSourceTest.java
@@ -1,0 +1,53 @@
+package hello.itemservice.message;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+public class MessageSourceTest {
+
+    @Autowired
+    MessageSource ms;
+
+    @Test
+    void helloMessqge() {
+        String result = ms.getMessage("hello", null, null);
+        assertThat(result).isEqualTo("안녕");
+    }
+
+    @Test
+    void notFoundMessageCode() {
+        assertThatThrownBy(() -> ms.getMessage("no_code", null, null))
+                .isInstanceOf(NoSuchMessageException.class);
+    }
+
+    @Test
+    void notFoundMessageCodeDefaultMessage() {
+        String result = ms.getMessage("no_code", null, "기본 메시지", null);
+        assertThat(result).isEqualTo("기본 메시지");
+    }
+
+    @Test
+    void argumentMessage() {
+        String message = ms.getMessage("hello.name", new Object[]{"Spring"}, null);
+        assertThat(message).isEqualTo("안녕 Spring");
+    }
+
+    @Test
+    void defalutLang() {
+        assertThat(ms.getMessage("hello", null, null)).isEqualTo("안녕");
+        assertThat(ms.getMessage("hello", null, Locale.KOREA)).isEqualTo("안녕");
+    }
+
+    @Test
+    void enLang() {
+        assertThat(ms.getMessage("hello", null, Locale.ENGLISH)).isEqualTo("hello");
+    }
+}


### PR DESCRIPTION
### 변경 내용
- MessageSource 인터페이스 사용법 테스트 코드 작성
- 메시지 조회, 기본 메시지 처리, 파라미터 바인딩, 국제화 메시지 선택 케이스 검증
- messages.properties에 hello, hello.name 메시지 추가
- messages_en.properties에 영어 메시지 추가

### 주요 테스트
- 메시지 키 존재 여부 확인
- 기본 메시지 처리 (`defaultMessage`)
- {0} 형식의 메시지 치환 테스트
- Locale.ENGLISH, Locale.KOREA 설정에 따른 메시지 선택 확인

### 참고 사항
- application.properties에 spring.messages.encoding=UTF-8 설정 필요
- messages.properties 파일은 반드시 UTF-8 인코딩으로 저장해야 함
